### PR TITLE
Only do CI builds on master and release branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
   - '10'
 
+branches:
+  only:
+  - master
+  - release
+
 addons:
   chrome: stable
 


### PR DESCRIPTION
This does not include builds for PRs.  This avoids double builds for
PRs.